### PR TITLE
Add blacklist feature

### DIFF
--- a/generalized_biffing/blacklist.txt
+++ b/generalized_biffing/blacklist.txt
@@ -1,0 +1,6 @@
+// List of files that should be excluded from the biffing operation.
+// Entries preceded by a colon (:) are treated as regular expressions.
+// EEex files:
+:B3.+\.lua
+:EEex_.+\.lua
+M___EEex.lua

--- a/generalized_biffing/generalized_biffing.tp2
+++ b/generalized_biffing/generalized_biffing.tp2
@@ -11,14 +11,17 @@ LANGUAGE ~English~
 
 LANGUAGE ~French (Traduction : Isaya)~
          ~french~
+         ~generalized_biffing/tra/english/setup.tra~
          ~generalized_biffing/tra/french/setup.tra~
 
 LANGUAGE ~Italiano~
          ~italian~
+         ~generalized_biffing/tra/english/setup.tra~
          ~generalized_biffing/tra/italian/setup.tra~
 
 LANGUAGE ~Brazilian Portuguese (translation by Felipe)~
          ~portuguese~
+         ~generalized_biffing/tra/english/setup.tra~
          ~generalized_biffing/tra/portuguese/setup.tra~
 
 

--- a/generalized_biffing/lib/functions.tph
+++ b/generalized_biffing/lib/functions.tph
@@ -1,0 +1,97 @@
+/**
+ * Initializes arrays of blacklisted files.
+ *
+ * STR_VAR blacklist_path       Path to the blacklist file. Can be used to override the default path.
+ * RET_ARRAY blacklisted        List of literal file names to blacklist.
+ * RET_ARRAY blacklisted_regexp List of regular expression patterns for blacklisted files.
+ */
+DEFINE_ACTION_FUNCTION gb#get_blacklisted_files
+STR_VAR
+  blacklist_path = EVAL ~%MOD_FOLDER%/blacklist.txt~
+RET_ARRAY
+  blacklisted
+  blacklisted_regexp
+BEGIN
+  COPY ~%blacklist_path%~ ~%blacklist_path%~
+    READ_2DA_ENTRIES_NOW ~gb_blacklisted~ 1
+    FOR (row = 0; row < gb_blacklisted; ++row) BEGIN
+      READ_2DA_ENTRY_FORMER ~gb_blacklisted~ row 0 string
+      LPF gb#normalize STR_VAR string RET string END
+      PATCH_IF (NOT ~%string%~ STR_EQ ~~) BEGIN
+        SET is_regexp = (INDEX(EXACT_MATCH ~:~ ~%string%~) = 0)
+        PATCH_IF (is_regexp) BEGIN
+          INNER_PATCH_SAVE string ~%string%~ BEGIN DELETE_BYTES 0 1 END
+          SET $blacklisted_regexp(~%string%~) = 1
+        END ELSE PATCH_IF (NOT ~%string%~ STR_EQ ~~) BEGIN
+          SET $blacklisted(~%string%~) = 1
+        END
+      END
+    END
+  BUT_ONLY IF_EXISTS
+END
+
+/**
+ * Determines whether a given filename should be blacklisted from the biffing operation.
+ *
+ * STR_VAR filename           File name to check for exclusion.
+ * STR_VAR blacklisted        Name of the array with literal file names to blacklist.
+ * STR_VAR blacklisted_regexp Name of the array with regular expressions patterns for blacklisted files.
+ * RET result                 A non-zero value indicates a match.
+ */
+DEFINE_ACTION_FUNCTION gb#is_blacklisted
+STR_VAR
+  filename = ~~
+  blacklisted = ~blacklisted~
+  blacklisted_regexp = ~blacklisted_regexp~
+RET
+  result  // non-zero result indicates a match
+BEGIN
+  LAF gb#normalize STR_VAR string = EVAL ~%filename%~ RET string END
+
+  // checking verbatim file list
+  OUTER_SET result = VARIABLE_IS_SET $EVAL ~%blacklisted%~(~%string%~)
+
+  ACTION_IF (NOT result) BEGIN
+    // checking regular expression list
+    ACTION_PHP_EACH EVAL ~%blacklisted_regexp%~ AS pattern => _ BEGIN
+      ACTION_IF (NOT result) BEGIN
+        OUTER_SET result = (~%string%~ STRING_MATCHES_REGEXP ~%pattern%~ = 0)
+      END
+    END
+  END
+END
+
+/**
+ * Normalizes a given string.
+ *
+ * INT_VAR trim           Boolean that indicates whether to remove leading and trailing spaces.
+ * INT_VAR lower_case     Boolean that indicates whether to lower-case the string.
+ * INT_VAR remove_comment Boolean that indicates whether to remove line comments.
+ * STR_VAR string         Contains the input string.
+ * RET string             Returns the normalized version of the input string.
+ */
+DEFINE_DIMORPHIC_FUNCTION gb#normalize
+INT_VAR
+  trim = 1            // whether to remove leading and trailing spaces
+  lower_case = 1      // whether to lower-case the string
+  remove_comment = 1  // whether to remove line comments
+STR_VAR
+  string = ~~         // input string
+RET
+  string              // normalized string
+BEGIN
+  OUTER_PATCH_SAVE string ~%string%~ BEGIN
+    PATCH_IF (remove_comment) BEGIN
+      REPLACE_TEXTUALLY ~//.*~ ~~
+    END
+
+    PATCH_IF (trim) BEGIN
+      REPLACE_TEXTUALLY ~^[ %TAB%%WNL%]+~ ~~
+      REPLACE_TEXTUALLY ~[ %TAB%%WNL%]+$~ ~~
+    END
+  END
+
+  ACTION_IF (lower_case) BEGIN
+    ACTION_TO_LOWER ~string~
+  END
+END

--- a/generalized_biffing/lib/main_component.tpa
+++ b/generalized_biffing/lib/main_component.tpa
@@ -2,6 +2,7 @@
  *         COMPONENT INSTALLATION         *
  * ====================================== */
 
+INCLUDE ~%MOD_FOLDER%/lib/functions.tph~
 
 /* --------------------------------------------------------- *
  *  biffing_all = 0 ==> Biff only .wav, .tis and .bam files  *
@@ -9,9 +10,9 @@
  * --------------------------------------------------------- */
 
 ACTION_IF ~%WEIDU_OS%~ STRING_COMPARE_CASE ~WIN32~ THEN BEGIN
-	AT_UNINSTALL ~rm -rf generalized_biffing/prod/0~
+  AT_UNINSTALL ~rm -rf generalized_biffing/prod/0~
 END ELSE BEGIN
-	AT_UNINSTALL ~del /q /f generalized_biffing\prod\0~ EXACT
+  AT_UNINSTALL ~del /q /f generalized_biffing\prod\0~ EXACT
 END
 
 <<<<<<<< .../list-of-files
@@ -29,7 +30,7 @@ ACTION_IF biffing_all BEGIN
   END ELSE BEGIN
     OUTER_TEXT_SPRINT ee_types ~~
   END
-	OUTER_TEXT_SPRINT ext ~\(2da\|are\|bam\|bcs\|bmp\|chr\|chu\|cre\|dlg\|eff\|gam\|ids\|ini\|itm\|mos\|mve\|plt\|pro\|spl\|sto\|tis\|vef\|vvc\|wav\|wed\|wfx\|wmp%ee_types%\)~
+  OUTER_TEXT_SPRINT ext ~\(2da\|are\|bam\|bcs\|bmp\|chr\|chu\|cre\|dlg\|eff\|gam\|ids\|ini\|itm\|mos\|mve\|plt\|pro\|spl\|sto\|tis\|vef\|vvc\|wav\|wed\|wfx\|wmp%ee_types%\)~
 END
 
 OUTER_TEXT_SPRINT ~myRegExp~ ~^%8char%\.%ext%$~
@@ -39,29 +40,40 @@ OUTER_TEXT_SPRINT ~myRegExp~ ~^%8char%\.%ext%$~
 MKDIR ~generalized_biffing/prod/0/biffs/0~
 MKDIR ~generalized_biffing/prod/0/rej~
 
+// getting list of files that must not be biffed
+LAF gb#get_blacklisted_files RET_ARRAY blacklisted blacklisted_regexp END
+
 OUTER_SET currentTotal = 0
 OUTER_SET currentFile = 0
 ACTION_BASH_FOR ~override~ ~%myRegExp%~ BEGIN
-	ACTION_IF %BASH_FOR_SIZE% + currentTotal > 30000000 /* 30M */ && currentTotal > 0 BEGIN
-		MAKE_BIFF ~tb#gen%currentFile%~ BEGIN ~generalized_biffing/prod/0/biffs/%currentFile%~ ~^.*$~ END
-		OUTER_SET currentFile = currentFile + 1
-		OUTER_SET currentTotal = 0
-		MKDIR ~generalized_biffing/prod/0/biffs/%currentFile%~
-	END
-	MOVE ~override/%BASH_FOR_FILE%~ ~generalized_biffing/prod/0/biffs/%currentFile%/%BASH_FOR_FILE%~
-	OUTER_SET currentTotal += BASH_FOR_SIZE
+  LAF gb#is_blacklisted STR_VAR filename = EVAL ~%BASH_FOR_FILE%~ RET result END
+  ACTION_IF (NOT result) BEGIN
+    ACTION_IF %BASH_FOR_SIZE% + currentTotal > 30000000 /* 30M */ && currentTotal > 0 BEGIN
+      MAKE_BIFF ~tb#gen%currentFile%~ BEGIN ~generalized_biffing/prod/0/biffs/%currentFile%~ ~^.*$~ END
+      OUTER_SET currentFile = currentFile + 1
+      OUTER_SET currentTotal = 0
+      MKDIR ~generalized_biffing/prod/0/biffs/%currentFile%~
+    END
+    MOVE ~override/%BASH_FOR_FILE%~ ~generalized_biffing/prod/0/biffs/%currentFile%/%BASH_FOR_FILE%~
+    OUTER_SET currentTotal += BASH_FOR_SIZE
+  END ELSE BEGIN
+    PRINT @100  // Skipping file: %BASH_FOR_FILE%
+  END
 END
-	
+
 ACTION_IF currentTotal > 0 BEGIN
-	MAKE_BIFF ~tb#gen%currentFile%~ BEGIN ~generalized_biffing/prod/0/biffs/%currentFile%~ ~^.*$~ END
+  MAKE_BIFF ~tb#gen%currentFile%~ BEGIN ~generalized_biffing/prod/0/biffs/%currentFile%~ ~^.*$~ END
 END
 
 OUTER_TEXT_SPRINT ~myRegExp~ ~^%9char%.%ext%$~
 ACTION_BASH_FOR ~override~ ~%myRegExp%~ BEGIN
-	OUTER_PATCH_SAVE ~8name~ ~%BASH_FOR_FILE%~ BEGIN
-		DELETE_BYTES 8 (INDEX_BUFFER (EXACT_MATCH ~.~) - 8)
-	END
-	ACTION_IF FILE_EXISTS_IN_GAME ~%8name%~ THEN BEGIN
-		MOVE ~override/%BASH_FOR_FILE%~ ~generalized_biffing/prod/0/rej/%BASH_FOR_FILE%~
-	END
+  LAF gb#is_blacklisted STR_VAR filename = EVAL ~%BASH_FOR_FILE%~ RET result END
+  ACTION_IF (NOT result) BEGIN
+    OUTER_PATCH_SAVE ~8name~ ~%BASH_FOR_FILE%~ BEGIN
+      DELETE_BYTES 8 (INDEX_BUFFER (EXACT_MATCH ~.~) - 8)
+    END
+    ACTION_IF FILE_EXISTS_IN_GAME ~%8name%~ THEN BEGIN
+      MOVE ~override/%BASH_FOR_FILE%~ ~generalized_biffing/prod/0/rej/%BASH_FOR_FILE%~
+    END
+  END
 END

--- a/generalized_biffing/tra/english/setup.tra
+++ b/generalized_biffing/tra/english/setup.tra
@@ -10,3 +10,5 @@ Would you like to biff only wav&tis files, or all files found?
 
 @10 = ~Biff only wav, tis & bam files (recommended by The Bigg and Small World Dudes)~
 @11 = ~Biff all files (recommended by the Big World Dudes)~
+
+@100 = ~Skipping file: %BASH_FOR_FILE%~


### PR DESCRIPTION
This feature allows biffing EE games without breaking the game when EEex is installed.

A text file in the mod folder contains all filenames and/or regexp patterns that should be excluded from the biffing operation.