### PR TITLE
Biff only ASCII files

### DIFF
--- a/generalized_biffing/blacklist.txt
+++ b/generalized_biffing/blacklist.txt
@@ -4,3 +4,5 @@
 :B3.+\.lua
 :EEex_.+\.lua
 M___EEex.lua
+// non-ASCII files:
+:.*[^!-~]+.*


### PR DESCRIPTION
As of WeiDU v247, some functions operating on the Latin-1 (8859-1) character set have been depracated and now use only US-ASCII characters. Biffing files with non-ASCII characters in their filenames may cause the game to crash.

@Argent77, how about using your blacklist feature to exclude all files with anything that isn't one of the printable characters 33-126 from the [ASCII](https://en.wikipedia.org/wiki/ASCII#Printable_characters) table?

`:.*[^!-~]+.*` seems to work fine with Infinity Animations. Is this OK or could there be potential issues I haven't thought about?